### PR TITLE
feat: add CI

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,10 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [ 'pull_request', 'push']
+
+jobs:
+  test:
+    name: Test on JDK ${{matrix.java-version}}
+    strategy:
+      matrix:
+        java-version: ["1.8", "11", "13"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Run tests
+        run: mvn test -B
+  mutation-testing:
+    name: Mutation testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Run mutation testing
+        run: mvn test-compile org.pitest:pitest-maven:mutationCoverage -B

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Perform a release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - uses: olafurpg/setup-gpg@v2
+      - name: Import GPG secret
+        run: echo $PGP_SECRET | base64 --decode | gpg --import
+      - name: Publish release
+      # GITHUB_REF
+        run: |
+          export REVISION="${GITHUB_REF:11}"
+          mvn --settings .github/settings.xml deploy -Drevision="${REVISION}" -P release -B
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.wmaarts/pitest-mutation-testing-elements-plugin.svg?color=brightgreen&label=Maven%20Central)](https://search.maven.org/artifact/io.github.wmaarts/pitest-mutation-testing-elements-plugin)
+[![Build status](https://github.com/wmaarts/pitest-mutation-testing-elements-plugin/workflows/CI/badge.svg)](https://github.com/wmaarts/pitest-mutation-testing-elements-plugin/actions)
 
 # pitest-mutation-testing-elements-plugin
 A pitest plugin that maps [pitest](https://github.com/hcoles/pitest) results to [stryker's mutation-testing-elements](https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-elements#mutation-testing-elements).
@@ -12,12 +13,12 @@ Like so:
     <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.4.7</version>
+        <version>1.4.10</version>
         <dependencies>
             <dependency>
                 <groupId>io.github.wmaarts</groupId>
                 <artifactId>pitest-mutation-testing-elements-plugin</artifactId>
-                <version>0.1.0</version>
+                <version>${pitest-mutation-testing-elements-plugin.version}</version>
             </dependency>
         </dependencies>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.wmaarts</groupId>
     <artifactId>pitest-mutation-testing-elements-plugin</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>pitest-mutation-testing-elements-plugin</name>
     <description>
         Write Pitest test results to mutation-testing-elements HTML reporter
@@ -53,13 +54,13 @@
         <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-entry</artifactId>
-            <version>1.4.9</version>
+            <version>1.4.10</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.6.2</version>
+            <version>2.8.6</version>
         </dependency>
         <dependency>
             <groupId>io.stryker-mutator</groupId>
@@ -77,7 +78,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.12.2</version>
+            <version>3.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -89,46 +90,45 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.pitest</groupId>
-                    <artifactId>pitest-maven</artifactId>
-                    <version>1.4.9</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.github.wmaarts</groupId>
-                            <artifactId>pitest-mutation-testing-elements-plugin</artifactId>
-                            <version>0.1.0</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <outputFormats>
-                            <format>HTML2</format>
-                        </outputFormats>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.4</version>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.4.10</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.github.wmaarts</groupId>
+                        <artifactId>pitest-mutation-testing-elements-plugin</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <outputFormats>
+                        <format>HTML2</format>
+                    </outputFormats>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <properties>
         <encoding>UTF-8</encoding>
+        <revision>MASTER-SNAPSHOT</revision>
         <!-- Release versions-->
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Happy Hacktoberfest 🎃🦇👻!

This adds two GitHub workflows for automated testing and releases:

- 🤖 Automated testing on JDK 8, 11 and 13
- 👽 Mutation testing
- 📦 Release to Sonatype on tag push (using the tag as the version)
- ✨ A shiny CI badge in the readme

You can view the CI (minus the release) working here: https://github.com/hugo-vrijswijk/pitest-mutation-testing-elements-plugin/commit/97d39ce94cd2bc598d5de719b2e9c04d094e6541/checks

Releases are done on tag push and should be in the `vx.x.x` format (note the leading `v`). Version in the `pom.xml` is now set to `MASTER-SNAPSHOT` and dynamically changed in CI to whatever the tag is (minus the `v`).

What needs to be done but I can't do:

- Add four secret variables to the build ([Repo Settings -> Secrets](https://github.com/wmaarts/pitest-mutation-testing-elements-plugin/settings/secrets))
  - `SONATYPE_USERNAME`: Either your sonatype username or an access token created in the [sonatype UI (Profile (top-right) -> Dropdown -> User Token)](https://oss.sonatype.org/) (recommended)
  - `SONATYPE_PASSWORD`: Same as the username, but with the password
  - `PGP_SECRET`: Output of  `gpg --armor --export-secret-keys $LONG_ID | base64 -w 0` where `$LONG_ID` is the long ID of the key (found with `gpg --list-keys`) 
  - `PGP_PASSPHRASE`: Your super secret password for the signing key
- Push a tag (or draft a new release from the [releases page](https://github.com/Wmaarts/pitest-mutation-testing-elements-plugin/releases)) and (hopefully) watch the magic!
- Optionally: set the CI as 'required' before being able to merge anything in the [branch settings -> edit master -> enable the status checks to be required](https://github.com/Wmaarts/pitest-mutation-testing-elements-plugin/settings/branches)