### PR TITLE
Update to use yourself with the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                     <dependency>
                         <groupId>io.github.wmaarts</groupId>
                         <artifactId>pitest-mutation-testing-elements-plugin</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.4.0</version>
                     </dependency>
                      <dependency>
                         <groupId>org.pitest</groupId>


### PR DESCRIPTION
Version `0.4.0` of `pitest-mutation-testing-elements-plugin` was just released.
Let's make `pitest-mutation-testing-elements-plugin` use the latest version of `pitest-mutation-testing-elements-plugin`.