### PR TITLE
Show which tests covered yet didn't kill a mutation

### DIFF
--- a/src/main/java/org/pitest/elements/models/json/JsonMutant.java
+++ b/src/main/java/org/pitest/elements/models/json/JsonMutant.java
@@ -6,17 +6,23 @@ public class JsonMutant {
   private String description;
   private JsonLocation location;
   private JsonMutantStatus status;
+  private String[] coveredBy;
+  private String[] killedBy;
 
   public JsonMutant(
       String id,
       String mutatorName,
       String description,
       JsonLocation location,
-      JsonMutantStatus status) {
+      JsonMutantStatus status,
+      String[] coveredBy,
+      String[] killedBy) {
     this.id = id;
     this.mutatorName = mutatorName;
     this.description = description;
     this.location = location;
     this.status = status;
+    this.coveredBy = coveredBy;
+    this.killedBy = killedBy;
   }
 }

--- a/src/main/java/org/pitest/elements/models/json/JsonReport.java
+++ b/src/main/java/org/pitest/elements/models/json/JsonReport.java
@@ -6,9 +6,11 @@ public class JsonReport {
   private String schemaVersion = "2";
   private JsonThresholds thresholds = new JsonThresholds(60, 80);
   private Map<String, JsonFile> files;
+  private Map<String, JsonTestFile> testFiles;
 
-  public JsonReport(Map<String, JsonFile> files) {
+  public JsonReport(Map<String, JsonFile> files, Map<String, JsonTestFile> testFiles) {
     this.files = files;
+    this.testFiles = testFiles;
   }
 }
 

--- a/src/main/java/org/pitest/elements/models/json/JsonTestDefinition.java
+++ b/src/main/java/org/pitest/elements/models/json/JsonTestDefinition.java
@@ -1,0 +1,23 @@
+package org.pitest.elements.models.json;
+
+public class JsonTestDefinition {
+
+  private String id;
+  private String name;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/org/pitest/elements/models/json/JsonTestFile.java
+++ b/src/main/java/org/pitest/elements/models/json/JsonTestFile.java
@@ -1,0 +1,15 @@
+package org.pitest.elements.models.json;
+
+import java.util.List;
+
+public class JsonTestFile {
+
+  private List<JsonTestDefinition> tests;
+
+  public void addTest(JsonTestDefinition test) {
+    if (this.tests == null) {
+      this.tests = new java.util.ArrayList<>();
+    }
+    this.tests.add(test);
+  }
+}

--- a/src/main/java/org/pitest/elements/utils/IdCounter.java
+++ b/src/main/java/org/pitest/elements/utils/IdCounter.java
@@ -1,6 +1,6 @@
 package org.pitest.elements.utils;
 
-public class MutationIdCounter {
+public class IdCounter {
   private int counter = 0;
 
   public int next() {

--- a/src/main/java/org/pitest/elements/utils/JsonParser.java
+++ b/src/main/java/org/pitest/elements/utils/JsonParser.java
@@ -169,7 +169,7 @@ public class JsonParser {
     String[] killedBy = null;
     if (areCoveringAndKillingTestsSupported()) {
       coveredBy =
-          mutation.getKillingTests().stream()
+          mutation.getCoveringTests().stream()
               .map(test -> testNamesWithId.getOrDefault(test, test))
               .toArray(String[]::new);
 
@@ -192,15 +192,11 @@ public class JsonParser {
   private boolean areCoveringAndKillingTestsSupported() {
     // check if getCoveringTests method exists
     try {
-      Class<?> mutationResultClass = Class.forName("org.pitest.mutationtest.MutationResult");
-      mutationResultClass.getMethod("getCoveringTests");
-      mutationResultClass.getMethod("getKillingTests");
+      MutationResult.class.getMethod("getCoveringTests");
+      MutationResult.class.getMethod("getKillingTests");
       return true;
     } catch (NoSuchMethodException e) {
       // If the method does not exist, return false
-      return false;
-    } catch (ClassNotFoundException e) {
-      // If the class is not found, return false
       return false;
     }
   }

--- a/src/main/java/org/pitest/elements/utils/JsonParser.java
+++ b/src/main/java/org/pitest/elements/utils/JsonParser.java
@@ -24,21 +24,26 @@ public class JsonParser {
 
   private final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
-  private final MutationIdCounter mutationIdCounter = new MutationIdCounter();
+  private final IdCounter mutationIdCounter = new IdCounter();
+  private final IdCounter testIdCounter = new IdCounter();
+  private final Map<String, String> testNamesWithId = new HashMap<>();
 
   public String toJson(final PackageSummaryMap packageSummaryMap) throws IOException {
     mutationIdCounter.reset();
+    testIdCounter.reset();
     final Map<String, JsonFile> collectedJsonFiles = new HashMap<>();
+    final Map<String, JsonTestFile> collectedJsonTestFiles = new HashMap<>();
 
     List<PackageSummaryData> sortedPackageData = packageSummaryMap.valuesList();
     Collections.sort(sortedPackageData);
 
     for (PackageSummaryData packageData : sortedPackageData) {
       for (MutationTestSummaryData testData : packageData.getSummaryData()) {
+        this.addToJsonTestFiles(collectedJsonTestFiles, testData);
         this.addToJsonFiles(collectedJsonFiles, testData);
       }
     }
-    final JsonReport report = new JsonReport(collectedJsonFiles);
+    final JsonReport report = new JsonReport(collectedJsonFiles, collectedJsonTestFiles);
     return gson.toJson(report, JsonReport.class);
   }
 
@@ -58,6 +63,46 @@ public class JsonParser {
     // Step 3: Add source and mutants to file
     file.addSource(this.getSourceFromLines(lines));
     file.addMutants(this.getMutantsFromLines(lines, data));
+  }
+
+  private void addToJsonTestFiles(
+      final Map<String, JsonTestFile> collectedJsonTestFiles, final MutationTestSummaryData data)
+      throws IOException {
+
+    data.getResults()
+        .forEach(
+            mutationResult -> {
+              mutationResult
+                  .getCoveringTests()
+                  .forEach(
+                      test -> {
+                        if (!testNamesWithId.containsKey(test)) {
+                          // Mark the test class name as file name
+                          // class name is all the text before ".["
+                          String testFileName = "";
+                          if (test.contains(".[")) {
+                            testFileName = test.substring(0, test.indexOf(".["));
+                          }
+
+                          JsonTestFile testFile;
+                          if (collectedJsonTestFiles.get(testFileName) == null) {
+                            testFile = new JsonTestFile();
+                            collectedJsonTestFiles.put(testFileName, testFile);
+                          } else {
+                            // If the test file already exists, use it
+                            testFile = collectedJsonTestFiles.get(testFileName);
+                          }
+
+                          String testId = Integer.toString(testIdCounter.next());
+                          testNamesWithId.put(test, testId);
+
+                          JsonTestDefinition jsonTestDefinition = new JsonTestDefinition();
+                          jsonTestDefinition.setId(testId);
+                          jsonTestDefinition.setName(test);
+                          testFile.addTest(jsonTestDefinition);
+                        }
+                      });
+            });
   }
 
   private List<JsonMutant> getMutantsFromLines(
@@ -119,6 +164,14 @@ public class JsonParser {
     final String fullMutatorName = mutation.getDetails().getMutator();
     // Only show the class name
     final String mutatorName = fullMutatorName.substring(fullMutatorName.lastIndexOf(".") + 1);
+    final String[] coveredBy =
+        mutation.getCoveringTests().stream()
+            .map(test -> testNamesWithId.getOrDefault(test, test))
+            .toArray(String[]::new);
+    final String[] killedBy =
+        mutation.getKillingTests().stream()
+            .map(test -> testNamesWithId.getOrDefault(test, test))
+            .toArray(String[]::new);
 
     final JsonMutantStatus status = JsonMutantStatus.fromPitestStatus(mutation.getStatus());
     return new JsonMutant(
@@ -126,6 +179,8 @@ public class JsonParser {
         mutatorName,
         mutation.getDetails().getDescription(),
         location,
-        status);
+        status,
+        coveredBy,
+        killedBy);
   }
 }

--- a/src/test/java/org/pitest/elements/testutils/JsonBuilder.java
+++ b/src/test/java/org/pitest/elements/testutils/JsonBuilder.java
@@ -2,6 +2,7 @@ package org.pitest.elements.testutils;
 
 import java.util.Collections;
 import java.util.List;
+import org.pitest.elements.models.json.JsonMutantStatus;
 import org.pitest.mutationtest.MutationResult;
 
 public class JsonBuilder {
@@ -47,8 +48,12 @@ public class JsonBuilder {
     return this;
   }
 
-  public JsonBuilder addTestFile() {
+  public JsonBuilder addTestFile(String fileName, String killingTest) {
     stringBuilder.append(testFilesBeginJson);
+    stringBuilder.append("\"").append(fileName);
+    stringBuilder.append("\":{\"tests\":[{\"id\":\"0\",\"name\":\"");
+    stringBuilder.append(killingTest);
+    stringBuilder.append("\"}]}");
     return this;
   }
 
@@ -60,15 +65,20 @@ public class JsonBuilder {
     stringBuilder.append(result.getDetails().getMutator());
     stringBuilder.append("\",\"description\":\"\",\"location\":");
     stringBuilder.append(locationToJson(lineNr));
-    stringBuilder.append(",\"status\":\"NoCoverage\"");
+    stringBuilder.append(
+        ",\"status\":\"" + JsonMutantStatus.fromPitestStatus(result.getStatus()) + "\"");
     if (result.getCoveringTests() != null) {
       stringBuilder.append(",\"coveredBy\":[");
-      stringBuilder.append(String.join(",", result.getCoveringTests()));
+      if (!result.getCoveringTests().isEmpty()) {
+        stringBuilder.append("\"0\"");
+      }
       stringBuilder.append("]");
     }
     if (result.getKillingTests() != null) {
       stringBuilder.append(",\"killedBy\":[");
-      stringBuilder.append(String.join(",", result.getKillingTests()));
+      if (!result.getKillingTests().isEmpty()) {
+        stringBuilder.append("\"0\"");
+      }
       stringBuilder.append("]");
     }
     stringBuilder.append("}");

--- a/src/test/java/org/pitest/elements/testutils/JsonBuilder.java
+++ b/src/test/java/org/pitest/elements/testutils/JsonBuilder.java
@@ -7,6 +7,7 @@ import org.pitest.mutationtest.MutationResult;
 public class JsonBuilder {
   private final String beginJson =
       "{\"schemaVersion\":\"2\",\"thresholds\":{\"high\":60,\"low\":80},\"files\":{";
+  private final String testFilesBeginJson = "},\"testFiles\":{";
   private final String endJson = "}}";
   private final StringBuilder stringBuilder;
   private int mutantCounter = 0;
@@ -46,6 +47,11 @@ public class JsonBuilder {
     return this;
   }
 
+  public JsonBuilder addTestFile() {
+    stringBuilder.append(testFilesBeginJson);
+    return this;
+  }
+
   private void addMutant(final MutationResult result) {
     final int lineNr = result.getDetails().getLineNumber();
     stringBuilder.append("{\"id\":\"");
@@ -54,7 +60,18 @@ public class JsonBuilder {
     stringBuilder.append(result.getDetails().getMutator());
     stringBuilder.append("\",\"description\":\"\",\"location\":");
     stringBuilder.append(locationToJson(lineNr));
-    stringBuilder.append(",\"status\":\"NoCoverage\"}");
+    stringBuilder.append(",\"status\":\"NoCoverage\"");
+    if (result.getCoveringTests() != null) {
+      stringBuilder.append(",\"coveredBy\":[");
+      stringBuilder.append(String.join(",", result.getCoveringTests()));
+      stringBuilder.append("]");
+    }
+    if (result.getKillingTests() != null) {
+      stringBuilder.append(",\"killedBy\":[");
+      stringBuilder.append(String.join(",", result.getKillingTests()));
+      stringBuilder.append("]");
+    }
+    stringBuilder.append("}");
   }
 
   private String locationToJson(final int lineNr) {
@@ -77,6 +94,9 @@ public class JsonBuilder {
   }
 
   public String build() {
+    if (stringBuilder.indexOf("testFiles") < 0) {
+      stringBuilder.append(testFilesBeginJson);
+    }
     stringBuilder.append(endJson);
     return stringBuilder.toString();
   }

--- a/src/test/java/org/pitest/elements/testutils/MutationResultBuilder.java
+++ b/src/test/java/org/pitest/elements/testutils/MutationResultBuilder.java
@@ -12,6 +12,7 @@ public class MutationResultBuilder {
 
   private int lineNumber = 1;
   private String className = "Foo";
+  private MutationStatusTestPair statusTestPair;
 
   public MutationResultBuilder lineNumber(int lineNumber) {
     this.lineNumber = lineNumber;
@@ -23,13 +24,18 @@ public class MutationResultBuilder {
     return this;
   }
 
+  public MutationResultBuilder statusTestPair(
+      int numberOfTestsRun, DetectionStatus status, String killingTestName) {
+    this.statusTestPair = new MutationStatusTestPair(numberOfTestsRun, status, killingTestName);
+    return this;
+  }
+
   public MutationResult build() {
     final Location location = new Location(ClassName.fromString(className), "", "constructor");
     final MutationIdentifier id =
         new MutationIdentifier(location, lineNumber, "id + " + lineNumber);
     final MutationDetails details = new MutationDetails(id, className + ".java", "", lineNumber, 0);
-    final MutationStatusTestPair pair =
-        new MutationStatusTestPair(0, DetectionStatus.NO_COVERAGE, null);
+    final MutationStatusTestPair pair = this.statusTestPair;
     return new MutationResult(details, pair);
   }
 }

--- a/src/test/java/org/pitest/elements/utils/JsonParserTest.java
+++ b/src/test/java/org/pitest/elements/utils/JsonParserTest.java
@@ -13,6 +13,7 @@ import org.pitest.elements.models.PackageSummaryMap;
 import org.pitest.elements.testutils.JsonBuilder;
 import org.pitest.elements.testutils.MockClassLines;
 import org.pitest.elements.testutils.MutationResultBuilder;
+import org.pitest.mutationtest.DetectionStatus;
 import org.pitest.mutationtest.MutationResult;
 import org.pitest.mutationtest.SourceLocator;
 
@@ -41,17 +42,21 @@ public class JsonParserTest {
     final JsonParser testee = createTestee();
     final String json =
         testee.toJson(createPackageSummaryMap(Collections.singletonList(fileName + ".java")));
-    final String expected = new JsonBuilder().addFile(fileName).addTestFile().build();
+    final String expected = new JsonBuilder().addFile(fileName).build();
     assertEquals(expected, json);
   }
 
   @Test
-  public void shouldParseAFileWithMutantsToJson() throws IOException {
+  public void shouldParseAFileWithMutantsAndTestFilesToJson() throws IOException {
     final String fileName = "Foo";
     final List<Integer> mutantLocations = Arrays.asList(1, 10, 15);
     final Map<String, List<MutationResult>> map = new HashMap<>();
-    final MutationResultBuilder builder = new MutationResultBuilder().className(fileName);
-
+    final String killingTest =
+        "com.example.TestFoo.[engine:junit-jupiter]/[class:org.example.TestFoo]/[method:testFoo()]";
+    final MutationResultBuilder builder =
+        new MutationResultBuilder()
+            .className(fileName)
+            .statusTestPair(1, DetectionStatus.KILLED, killingTest);
     final List<MutationResult> mutationResults = new ArrayList<>();
     for (Integer line : mutantLocations) {
       mutationResults.add(builder.lineNumber(line).build());
@@ -64,8 +69,31 @@ public class JsonParserTest {
     final String expected =
         new JsonBuilder()
             .addFile(fileName, sourceLocator.getSource(), mutationResults)
-            .addTestFile()
+            .addTestFile("com.example.TestFoo", killingTest)
             .build();
+    assertEquals(expected, json);
+  }
+
+  @Test
+  public void shouldParseAFileWithMutantsAndNoTestFilesToJson() throws IOException {
+    final String fileName = "Foo";
+    final List<Integer> mutantLocations = Arrays.asList(1, 10, 15);
+    final Map<String, List<MutationResult>> map = new HashMap<>();
+    final MutationResultBuilder builder =
+        new MutationResultBuilder()
+            .className(fileName)
+            .statusTestPair(0, DetectionStatus.NO_COVERAGE, null);
+    final List<MutationResult> mutationResults = new ArrayList<>();
+    for (Integer line : mutantLocations) {
+      mutationResults.add(builder.lineNumber(line).build());
+    }
+    map.put(fileName + ".java", mutationResults);
+
+    final MockSourceLocator sourceLocator = new MockSourceLocator(20);
+    final JsonParser testee = createTestee(sourceLocator);
+    final String json = testee.toJson(createPackageSummaryMap(map));
+    final String expected =
+        new JsonBuilder().addFile(fileName, sourceLocator.getSource(), mutationResults).build();
     assertEquals(expected, json);
   }
 

--- a/src/test/java/org/pitest/elements/utils/JsonParserTest.java
+++ b/src/test/java/org/pitest/elements/utils/JsonParserTest.java
@@ -41,7 +41,7 @@ public class JsonParserTest {
     final JsonParser testee = createTestee();
     final String json =
         testee.toJson(createPackageSummaryMap(Collections.singletonList(fileName + ".java")));
-    final String expected = new JsonBuilder().addFile(fileName).build();
+    final String expected = new JsonBuilder().addFile(fileName).addTestFile().build();
     assertEquals(expected, json);
   }
 
@@ -62,7 +62,10 @@ public class JsonParserTest {
     final JsonParser testee = createTestee(sourceLocator);
     final String json = testee.toJson(createPackageSummaryMap(map));
     final String expected =
-        new JsonBuilder().addFile(fileName, sourceLocator.getSource(), mutationResults).build();
+        new JsonBuilder()
+            .addFile(fileName, sourceLocator.getSource(), mutationResults)
+            .addTestFile()
+            .build();
     assertEquals(expected, json);
   }
 


### PR DESCRIPTION
PIT [now supports](https://github.com/hcoles/pitest/pull/1340) reporting which tests "covered but did not kill" a mutation.

This PR enables this feature in this plugin too.  This helps in immediately identifying which tests need improvement.

Sample screenshots:

<img width="2674" height="878" alt="image" src="https://github.com/user-attachments/assets/d0d92200-9427-42ba-8e46-2d783d2f020a" />

<img width="1644" height="849" alt="image" src="https://github.com/user-attachments/assets/04d0cbef-343a-4a2e-813c-dbc80081a6ad" />

<img width="1786" height="517" alt="image" src="https://github.com/user-attachments/assets/2469c1a4-c99b-41ef-9e7f-9599ac829937" />

<img width="2236" height="1032" alt="image" src="https://github.com/user-attachments/assets/5e4292af-3e94-40d1-9afc-baec337fc337" />

