### PR TITLE
suggestion for sonatype central deployment fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+          server-id: central
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
       - name: Import GPG secret
         run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:


### PR DESCRIPTION
@hugo-vrijswijk I noticed that you were trying to move to sonatype central for publishing.

This PR is a suggestion to fix the release job, with reference from [pitest repo](https://github.com/hcoles/pitest/blob/master/.github/workflows/release.yml#L33)

### RCA

Looking at the HTTP 401 response code in this [log](https://github.com/Wmaarts/pitest-mutation-testing-elements-plugin/actions/runs/16720828339/job/47324683443#step:6:389), I am guessing the credentials are not getting passed to the job.

Hence, trying the params that come with `actions/setup-java@v4` like in `pitest` repo could prove useful in fixing this error.
